### PR TITLE
remix/config: remove tailwind flag

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -1,6 +1,5 @@
 /** @type {import('@remix-run/dev').AppConfig} */
 module.exports = {
   ignoredRouteFiles: ['**/.*'],
-  tailwind: true,
   serverModuleFormat: 'cjs',
 }


### PR DESCRIPTION
In remix v2 tailwind is natively supported and also enabled by default. Docs: https://remix.run/docs/en/main/styling/tailwind