### PR TITLE
Change OGPreview to use ``options.url` as value not function

### DIFF
--- a/app/sanity/components/OGPreview.tsx
+++ b/app/sanity/components/OGPreview.tsx
@@ -5,7 +5,7 @@ import {OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH} from '~/routes/resource.og'
 
 export default function OGPreview({document, options}: any) {
   const {displayed} = document
-  const url = React.useMemo(() => options.url(displayed), [displayed, options])
+  const url = React.useMemo(() => options.url, [displayed, options])
 
   return (
     <Flex


### PR DESCRIPTION
In my testing, it seems that `options.url` is not a function, but rather a value. I did leave displayed in the dependency array as I figured the value to display on the og image could change. This could be wrong.