### PR TITLE
Switch to named exports for lazy loaded components

### DIFF
--- a/app/components/ExitPreview.tsx
+++ b/app/components/ExitPreview.tsx
@@ -1,8 +1,6 @@
 import {useEffect, useState} from 'react'
 
-// Default export required for lazy loading
-// eslint-disable-next-line import/no-default-export
-export default function ExitPreview() {
+export function ExitPreview() {
   const [inIframe, setInIframe] = useState(true)
   useEffect(() => {
     setInIframe(window.self !== window.top)

--- a/app/components/SanityLiveMode.tsx
+++ b/app/components/SanityLiveMode.tsx
@@ -10,9 +10,7 @@ const liveClient = client.withConfig({
   },
 })
 
-// Default export required for lazy loading
-// eslint-disable-next-line import/no-default-export
-export default function SanityLiveMode() {
+export function SanityLiveMode() {
   useLiveMode({client: liveClient})
 
   return null

--- a/app/routes/_website.tsx
+++ b/app/routes/_website.tsx
@@ -20,8 +20,16 @@ import type {HomeDocument} from '~/types/home'
 import {homeZ} from '~/types/home'
 import type {ThemePreference} from '~/types/themePreference'
 
-const SanityLiveMode = lazy(() => import('~/components/SanityLiveMode'))
-const ExitPreview = lazy(() => import('~/components/ExitPreview'))
+const SanityLiveMode = lazy(() =>
+  import('~/components/SanityLiveMode').then((module) => ({
+    default: module.SanityLiveMode,
+  })),
+)
+const ExitPreview = lazy(() =>
+  import('~/components/ExitPreview').then((module) => ({
+    default: module.ExitPreview,
+  })),
+)
 
 export const loader = async ({request}: LoaderFunctionArgs) => {
   const {preview, options} = await loadQueryOptions(request.headers)


### PR DESCRIPTION
Small change to prevent having to use `eslint-disable-next-line import/no-default-export` 