### PR TITLE
Remove old PRODUCTION_URL note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Visit `https://localhost:3000/studio` in your Remix app. You will need to:
 This Remix template is specifically configured for hosting on Vercel.
 
 1. Check this repository into your own source control (like GitHub) and deploy to Vercel.
-2. You will need to update `PRODUCTION_URL` in `./app/sanity/projectDetails.ts` to match your production URL. This value is used to enable "stega" encoding on all URLs other than in production. And when using the production URL to view the Studio will load the production build at one of the other automatically generated URLs.
 
 ### Using a Template
 


### PR DESCRIPTION
Updated the readme, as this section appears to no longer be applicable. 

Not sure if some new additional information needs to be added here - Presentation seems to be working locally for me, but when deployed to Vercel, the presentation panel says "No Matching Documents" and there are no clickable blue outlines on the visual editor panel. Also worth noting that I forked the repo a few moths ago and don't have the latest commits in my project yet. 